### PR TITLE
fix/fail typecheck ci

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -2,6 +2,9 @@ name: static-analysis
 on:
   workflow_dispatch:
   merge_group:
+  push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
- ci: デプロイ時のブランチをマージキューなどからref_nameに変更
- fix: 続テンプレートのtaconfig修正
- fix: マージキューが発動しない問題に対処
